### PR TITLE
chore(import): fix not used import

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ import esbuild from 'rollup-plugin-esbuild'
 import json from '@rollup/plugin-json'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
-import alias from '@rollup/plugin-alias'
 
 export default {
   input: 'src/index.ts',


### PR DESCRIPTION
When doing yarn would return this warning

<img width="747" alt="Captura de ecrã 2022-07-20, às 17 55 29" src="https://user-images.githubusercontent.com/29093946/180039886-fc34fada-20da-4fa2-8ffb-b23b1027d7b5.png">

due to

<img width="443" alt="Captura de ecrã 2022-07-20, às 17 55 43" src="https://user-images.githubusercontent.com/29093946/180039900-579d5462-1012-4817-ade8-3a012521b6ab.png">


this PR removes that not used import

